### PR TITLE
Fix database file size not shrinking when `document_ttl` triggers squash

### DIFF
--- a/src/pycrdt/store/store.py
+++ b/src/pycrdt/store/store.py
@@ -427,6 +427,9 @@ class SQLiteYStore(BaseYStore):
                 )
                 async with db:
                     cursor = await db.cursor()
+                    # enable full auto-vacuum & rebuild now
+                    await cursor.execute("PRAGMA auto_vacuum = FULL")
+                    await cursor.execute("VACUUM")
                     await cursor.execute(
                         "CREATE TABLE yupdates (path TEXT NOT NULL, yupdate BLOB, "
                         "metadata BLOB, timestamp REAL NOT NULL)"


### PR DESCRIPTION
### Fixes https://github.com/y-crdt/pycrdt-websocket/issues/116

### Description

SQLite normally keeps freed pages in its internal freelist and only returns them to the OS when you rebuild the file. By turning on **full auto-vacuum** at database creation, any subsequent `DELETE` (including our TTL-based squash) will automatically release pages back to the OS—so the file will shrink as soon as old updates are purged.

### Code changes

```diff
+ # enable full auto-vacuum & rebuild now
+ await cursor.execute("PRAGMA auto_vacuum = FULL")
+ await cursor.execute("VACUUM")
```

### Verification

logging number of rows and db file size
```bash
Number of updates before: 123
SQLite file size before: 36864.00 Bytes
document_ttl:  1 

Number of updates after: 124
SQLite file size after: 36864.00 Bytes

# Updating after waiting for 2 seconds

Number of updates before: 124
SQLite file size before: 36864.00 Bytes
document_ttl:  1 

**Deleting history and squashing updates**

Number of updates after: 2
SQLite file size after: 36864.00 Bytes  # not immediately reflected in file size

Number of updates before: 2
SQLite file size before: 16384.00 Bytes # Size is reduced
document_ttl:  1 
```