### PR TITLE
fix import of `YDocNotFound`

### DIFF
--- a/src/pycrdt/store/__init__.py
+++ b/src/pycrdt/store/__init__.py
@@ -1,5 +1,6 @@
 from .store import BaseYStore as BaseYStore
 from .store import SQLiteYStore as SQLiteYStore
 from .store import TempFileYStore as TempFileYStore
+from .store import YDocNotFound as YDocNotFound
 
 __version__ = "0.1.0"


### PR DESCRIPTION
### Description
`jupyter-server-ydoc` requires `YDocNotFound` from `pycrdt.store`, but it wasn't being exposed.
CI error: https://github.com/jupyterlab/jupyter-collaboration/actions/runs/14774032452/job/41478969976?pr=480