### PR TITLE
Compress yupdates to reduce SQLite DB file size

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "anyio >=3.6.2,<5",
     "sqlite-anyio >=0.2.3,<0.3.0",
     "pycrdt >=0.12.13,<0.13.0",
+    "lz4 >= 4.0.0"
 ]
 
 [project.optional-dependencies]

--- a/src/pycrdt/store/store.py
+++ b/src/pycrdt/store/store.py
@@ -464,7 +464,10 @@ class SQLiteYStore(BaseYStore):
                         (self.path,),
                     )
                     for update, metadata, timestamp in await cursor.fetchall():
-                        update = lz4.frame.decompress(update)
+                        try:
+                            update = lz4.frame.decompress(update)
+                        except lz4.frame.LZ4FrameError:
+                            pass
                         found = True
                         yield update, metadata, timestamp
                 if not found:

--- a/src/pycrdt/store/store.py
+++ b/src/pycrdt/store/store.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Callable, cast
 
 import anyio
+import lz4.frame
 from anyio import TASK_STATUS_IGNORED, Event, Lock, create_task_group
 from anyio.abc import TaskGroup, TaskStatus
 from sqlite_anyio import Connection, connect, exception_logger
@@ -463,6 +464,7 @@ class SQLiteYStore(BaseYStore):
                         (self.path,),
                     )
                     for update, metadata, timestamp in await cursor.fetchall():
+                        update = lz4.frame.decompress(update)
                         found = True
                         yield update, metadata, timestamp
                 if not found:
@@ -504,15 +506,17 @@ class SQLiteYStore(BaseYStore):
                     await cursor.execute("DELETE FROM yupdates WHERE path = ?", (self.path,))
                     # insert squashed updates
                     squashed_update = ydoc.get_update()
+                    compressed_update = lz4.frame.compress(squashed_update, compression_level=0)
                     metadata = await self.get_metadata()
                     await cursor.execute(
                         "INSERT INTO yupdates VALUES (?, ?, ?, ?)",
-                        (self.path, squashed_update, metadata, time.time()),
+                        (self.path, compressed_update, metadata, time.time()),
                     )
 
                 # finally, write this update to the DB
                 metadata = await self.get_metadata()
+                compressed_data = lz4.frame.compress(data, compression_level=0)
                 await cursor.execute(
                     "INSERT INTO yupdates VALUES (?, ?, ?, ?)",
-                    (self.path, data, metadata, time.time()),
+                    (self.path, compressed_data, metadata, time.time()),
                 )


### PR DESCRIPTION
## References https://github.com/jupyterlab/jupyter-collaboration/issues/430

## Summary

This PR introduces compression of `yupdates` using the `lz4` package to reduce the size of the `.ystore.db` file created by `pycrdt-store`.

## Problem

For frequently edited or large documents, the `.ystore.db` file grows excessively large. Users have repeatedly raised concerns about its size.

To address this we have:
- `document_ttl`
- `history_length` or `history_size` in [this PR](https://github.com/y-crdt/pycrdt-store/pull/2)

However, these approaches involve tradeoffs such as deleting history. A better long-term solution is to reduce the size of each update stored in the database.

## Proposed Solution

This PR compresses each `yupdate` using `lz4.frame.compress()` before storing it in the database, and decompresses using `lz4.frame.decompress()` during retrieval.

Key details:

- Uses `lz4.frame.compress()` with `compression_level=0` for a balance between speed and compression ratio.
- Read and Write performance is nearly unaffected, making it suitable for real-time editing.

## Benefits

While small frequent updates don’t compress significantly, large updates benefit greatly.

**Example Results:**

- A `.db` file of size **192 MB** was reduced to **64 MB** using this compression method.
- A project folder (uses `jupyter collaboration`) with `.db` files totaling **1 GB** was reduced to **200 MB** after applying this change.

This allows:
- Longer history retention
- Lower disk usage

## Migration Strategy

No changes are required from existing users because the system detects compression and handles both old (uncompressed) and new (compressed) updates.