### PR TITLE
Add RamYStore for in-memory document storage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "anyio >=3.6.2,<5",
     "sqlite-anyio >=0.2.3,<0.3.0",
     "pycrdt >=0.12.13,<0.13.0",
+    "lz4 >= 4.0.0"
 ]
 
 [project.optional-dependencies]

--- a/src/pycrdt/store/__init__.py
+++ b/src/pycrdt/store/__init__.py
@@ -1,4 +1,5 @@
 from .store import BaseYStore as BaseYStore
+from .store import RamYStore as RamYStore
 from .store import SQLiteYStore as SQLiteYStore
 from .store import TempFileYStore as TempFileYStore
 from .store import YDocNotFound as YDocNotFound

--- a/src/pycrdt/store/store.py
+++ b/src/pycrdt/store/store.py
@@ -464,7 +464,10 @@ class SQLiteYStore(BaseYStore):
                         (self.path,),
                     )
                     for update, metadata, timestamp in await cursor.fetchall():
-                        update = lz4.frame.decompress(update)
+                        try:
+                            update = lz4.frame.decompress(update)
+                        except lz4.frame.LZ4FrameError:
+                            pass
                         found = True
                         yield update, metadata, timestamp
                 if not found:

--- a/src/pycrdt/store/store.py
+++ b/src/pycrdt/store/store.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Callable, cast
 
 import anyio
+import lz4.frame
 from anyio import TASK_STATUS_IGNORED, Event, Lock, create_task_group
 from anyio.abc import TaskGroup, TaskStatus
 from sqlite_anyio import Connection, connect, exception_logger
@@ -463,6 +464,7 @@ class SQLiteYStore(BaseYStore):
                         (self.path,),
                     )
                     for update, metadata, timestamp in await cursor.fetchall():
+                        update = lz4.frame.decompress(update)
                         found = True
                         yield update, metadata, timestamp
                 if not found:
@@ -504,15 +506,17 @@ class SQLiteYStore(BaseYStore):
                     await cursor.execute("DELETE FROM yupdates WHERE path = ?", (self.path,))
                     # insert squashed updates
                     squashed_update = ydoc.get_update()
+                    compressed_update = lz4.frame.compress(squashed_update, compression_level=0)
                     metadata = await self.get_metadata()
                     await cursor.execute(
                         "INSERT INTO yupdates VALUES (?, ?, ?, ?)",
-                        (self.path, squashed_update, metadata, time.time()),
+                        (self.path, compressed_update, metadata, time.time()),
                     )
 
                 # finally, write this update to the DB
                 metadata = await self.get_metadata()
+                compressed_data = lz4.frame.compress(data, compression_level=0)
                 await cursor.execute(
                     "INSERT INTO yupdates VALUES (?, ?, ?, ?)",
-                    (self.path, data, metadata, time.time()),
+                    (self.path, compressed_data, metadata, time.time()),
                 )


### PR DESCRIPTION
### Description

Currently, we can store document updates in persistent storage or the `/tmp` directory (`TempFileYStore`). However, there are scenarios where:

- We want to clear storage clear after each session (not just reboots).
- `/tmp` may be inaccessible or unsuitable.

### Solution: `RamYStore`

Implement a `RamYStore` class that:

- Stores updates entirely in RAM.
- Clears data when the process ends.
- Squashes document updates to limit memory growth.