### PR TITLE
Fix in-memory database connection issue with SQLiteYStore

### DIFF
--- a/src/pycrdt/store/store.py
+++ b/src/pycrdt/store/store.py
@@ -435,12 +435,13 @@ class SQLiteYStore(BaseYStore):
                         "CREATE INDEX idx_yupdates_path_timestamp ON yupdates (path, timestamp)"
                     )
                     await cursor.execute(f"PRAGMA user_version = {self.version}")
-                await db.close()
-        self._db = await connect(
-            self.db_path,
-            exception_handler=exception_logger,
-            log=self.log,
-        )
+            self._db = db
+        else:
+            self._db = await connect(
+                self.db_path,
+                exception_handler=exception_logger,
+                log=self.log,
+            )
         assert self.db_initialized is not None
         self.db_initialized.set()
 


### PR DESCRIPTION
### Problem

When using `:memory:` as the `db_path` to store data in RAM (which clears storage after each session), we encountered an error where tables we created would disappear between operations. This happened because the database connection was being closed and recreated, causing the in-memory database to be destroyed and recreated without any tables.

#### Relevant error logs:
```
Executing SELECT query for path: .notebook:b5f8579d-30c2-4600-9e2f-960d1695048c.y
SQLite exception
sqlite3.OperationalError: no such table: yupdates
```

### Solution

The key issue was that in SQLite, in-memory databases only exist for the duration of the database connection. When a connection is closed, the entire database (including all tables and data) is destroyed.
This PR fixes the issue by not closing the connection after creating the database schema. Instead, we reuse the same connection instance throughout the lifetime of the `SQLiteYStore`