### PR TITLE
Expose `FileYStore`

### DIFF
--- a/src/pycrdt/store/__init__.py
+++ b/src/pycrdt/store/__init__.py
@@ -1,4 +1,5 @@
 from .store import BaseYStore as BaseYStore
+from .store import FileYStore as FileYStore
 from .store import SQLiteYStore as SQLiteYStore
 from .store import TempFileYStore as TempFileYStore
 from .store import YDocNotFound as YDocNotFound


### PR DESCRIPTION
### Description

Add `FileYStore` to `__init__.py` to allow direct import via `from pycrdt.store import FileYStore`.