### PR TITLE
Release 0.1.3 beta0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history
 
+## 0.1.3b0
+
+- Improve `SQLiteYStore` performance by storing and applying checkpoints to reduce loading time.
+
 ## 0.1.2
 
 - Fix in-memory database connection issue with `SQLiteYStore`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pycrdt-store"
-version = "0.1.2"
+version = "0.1.3b0"
 description = "Persistent storage for pycrdt"
 license = { file = "LICENSE" }
 readme = "README.md"


### PR DESCRIPTION
I think this is what's needed to prepare release, then I just create a `0.1.3b0` tag an automation should handle it, right?